### PR TITLE
fix: make RemoteKeyStore key lookups thread-safe

### DIFF
--- a/jwks.go
+++ b/jwks.go
@@ -28,38 +28,28 @@ type RemoteKeyStore struct {
 // ByUse returns a key from RemoteKeyStore by use. If the keystore contains
 // multiple keys with same use then first key will be returned.
 func (r *RemoteKeyStore) ByUse(use string) (*jose.JSONWebKey, error) {
-	// Let's refresh the keys if cached keys expire within the next 10 minutes
-	tenMinutesFromNow := time.Now().UTC().Add(10 * time.Minute)
-	if tenMinutesFromNow.After(r.Expiry.Add(-1 * time.Second)) {
-		err := r.updateKeys()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	for _, key := range r.Keys {
-		if key.Use == use {
-			return &key, nil
-		}
-	}
-
-	return nil, errors.New("key not found")
+	return r.find(func(key jose.JSONWebKey) bool { return key.Use == use })
 }
 
 // ById returns a key from RemoteKeyStore by key id. If the RemoteKeyStore
 // contains multiple keys with same id then first matching key is returned.
 func (r *RemoteKeyStore) ById(kid string) (*jose.JSONWebKey, error) {
-	// Let's refresh the keys if cached keys expire within the next 10 minutes
-	tenMinutesFromNow := time.Now().UTC().Add(10 * time.Minute)
-	if tenMinutesFromNow.After(r.Expiry) {
-		err := r.updateKeys()
-		if err != nil {
-			return nil, err
-		}
+	return r.find(func(key jose.JSONWebKey) bool { return key.KeyID == kid })
+}
+
+// find refreshes the keys if needed and returns the first key matching match.
+// The returned key is a copy, so it stays valid after the next refresh.
+func (r *RemoteKeyStore) find(match func(jose.JSONWebKey) bool) (*jose.JSONWebKey, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if err := r.refreshIfExpiring(); err != nil {
+		return nil, err
 	}
 
-	for _, key := range r.Keys {
-		if key.KeyID == kid {
+	for i := range r.Keys {
+		if match(r.Keys[i]) {
+			key := r.Keys[i]
 			return &key, nil
 		}
 	}
@@ -67,11 +57,20 @@ func (r *RemoteKeyStore) ById(kid string) (*jose.JSONWebKey, error) {
 	return nil, errors.New("key not found")
 }
 
-// updateKeys updates the keys and expiration in RemoteKeyStore.
+// refreshIfExpiring refreshes the cached keys if they expire within the next
+// 10 minutes. The caller must hold r.mutex.
+func (r *RemoteKeyStore) refreshIfExpiring() error {
+	tenMinutesFromNow := time.Now().UTC().Add(10 * time.Minute)
+	if tenMinutesFromNow.After(r.Expiry) {
+		return r.updateKeys()
+	}
+	return nil
+}
+
+// updateKeys updates the keys and expiration in RemoteKeyStore. The caller
+// must hold r.mutex.
 func (r *RemoteKeyStore) updateKeys() error {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	keys, expiry, err := updateKeys(r.Context, r.JwksURI)
+	keys, expiry, err := fetchKeys(r.Context, r.JwksURI)
 	if err != nil {
 		return err
 	}
@@ -84,7 +83,7 @@ func (r *RemoteKeyStore) updateKeys() error {
 // the provider JWKS from the jwks_uri. Returns a RemoteKeyStore containing
 // the keys.
 func providerRemoteKeys(ctx context.Context, jwksUri string) (*RemoteKeyStore, error) {
-	keys, expiry, err := updateKeys(ctx, jwksUri)
+	keys, expiry, err := fetchKeys(ctx, jwksUri)
 	if err != nil {
 		return nil, err
 	}
@@ -96,9 +95,9 @@ func providerRemoteKeys(ctx context.Context, jwksUri string) (*RemoteKeyStore, e
 	}, nil
 }
 
-// updateKeys fetches the provider's JWKS from jwks_uri. The function respects
-// cache headers and caches the results for the specified time period.
-func updateKeys(ctx context.Context, jwksUri string) ([]jose.JSONWebKey, time.Time, error) {
+// fetchKeys fetches the provider's JWKS from jwks_uri. The function respects
+// cache headers and returns the expiry for the specified time period.
+func fetchKeys(ctx context.Context, jwksUri string) ([]jose.JSONWebKey, time.Time, error) {
 	req, err := http.NewRequest("GET", jwksUri, nil)
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("unable to create request: %w", err)

--- a/jwks_test.go
+++ b/jwks_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/go-jose/go-jose/v3"
@@ -340,9 +341,55 @@ var _ = Describe("Jwks tests", func() {
 				Expect(err.Error()).To(ContainSubstring("unable to fetch keys"))
 			})
 		})
+
+		Describe("concurrent access", func() {
+			It("is safe to read and refresh keys from multiple goroutines", func() {
+				body := fmt.Sprintf(`{"keys":[%s, %s]}`, signKeyMarshaled, encKeyMarshaled)
+				// No Cache-Control header means the keys expire immediately, so
+				// every lookup triggers a refresh (a write to the key store).
+				// Combined with concurrent readers this exercises the read/write
+				// path that must be serialised by the mutex. The round trip uses
+				// no shared mutable state, so it is itself safe to call
+				// concurrently.
+				mockClient := newMockClient(func(req *http.Request) (*http.Response, error) {
+					headers := http.Header{
+						"Content-Type": {"application/json"},
+					}
+					return newMockResponse(http.StatusOK, headers, body), nil
+				})
+
+				ctx := context.Background()
+				ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, mockClient)
+				remoteKeys, err := providerRemoteKeys(ctxWithClient, uri)
+				Expect(err).To(BeNil())
+
+				const goroutines = 16
+				const iterations = 50
+				var wg sync.WaitGroup
+				wg.Add(goroutines)
+				for g := 0; g < goroutines; g++ {
+					go func(g int) {
+						defer GinkgoRecover()
+						defer wg.Done()
+						for i := 0; i < iterations; i++ {
+							if (g+i)%2 == 0 {
+								key, err := remoteKeys.ByUse("enc")
+								Expect(err).To(BeNil())
+								Expect(key.KeyID).To(Equal(encKeyId))
+							} else {
+								key, err := remoteKeys.ById(signKeyId)
+								Expect(err).To(BeNil())
+								Expect(key.KeyID).To(Equal(signKeyId))
+							}
+						}
+					}(g)
+				}
+				wg.Wait()
+			})
+		})
 	})
 
-	Describe("updateKeys", func() {
+	Describe("fetchKeys", func() {
 		It("updates the keys successfully", func() {
 			signKeyId := generateId()
 			signKey, _ := rsa.GenerateKey(rand.Reader, 2048)
@@ -383,7 +430,7 @@ var _ = Describe("Jwks tests", func() {
 
 			ctx := context.Background()
 			ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, mockClient)
-			jwks, expiry, err := updateKeys(ctxWithClient, uri)
+			jwks, expiry, err := fetchKeys(ctxWithClient, uri)
 
 			now := time.Now().UTC()
 			Expect(jwks).To(Equal(expectedKeySet.Keys))
@@ -393,7 +440,7 @@ var _ = Describe("Jwks tests", func() {
 
 		It("fails when request cannot be created", func() {
 			invalidUri := string([]byte{0x7f})
-			jwks, expiry, err := updateKeys(context.TODO(), invalidUri)
+			jwks, expiry, err := fetchKeys(context.TODO(), invalidUri)
 			invalidCharacter := "\u007f"
 			expectedError := fmt.Sprintf("unable to create request: parse %q: net/url: invalid control character in URL", invalidCharacter)
 			Expect(jwks).To(BeNil())
@@ -409,7 +456,7 @@ var _ = Describe("Jwks tests", func() {
 
 			ctx := context.Background()
 			ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, mockClient)
-			jwks, expiry, err := updateKeys(ctxWithClient, uri)
+			jwks, expiry, err := fetchKeys(ctxWithClient, uri)
 
 			expectedError := "unable to fetch keys: Get \"https://example.com/oidc/jwks.json\": request failed"
 			Expect(jwks).To(BeNil())
@@ -429,7 +476,7 @@ var _ = Describe("Jwks tests", func() {
 
 			ctx := context.Background()
 			ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, mockClient)
-			jwks, expiry, err := updateKeys(ctxWithClient, uri)
+			jwks, expiry, err := fetchKeys(ctxWithClient, uri)
 
 			expectedError := fmt.Sprintf("unable to get keys: %s %s", http.StatusText(http.StatusInternalServerError), body)
 			Expect(jwks).To(BeNil())
@@ -453,7 +500,7 @@ var _ = Describe("Jwks tests", func() {
 
 			ctx := context.Background()
 			ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, mockClient)
-			jwks, expiry, err := updateKeys(ctxWithClient, uri)
+			jwks, expiry, err := fetchKeys(ctxWithClient, uri)
 
 			Expect(jwks).To(BeNil())
 			Expect(err).NotTo(BeNil())
@@ -498,7 +545,7 @@ var _ = Describe("Jwks tests", func() {
 
 			ctx := context.Background()
 			ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, mockClient)
-			jwks, expiry, err := updateKeys(ctxWithClient, uri)
+			jwks, expiry, err := fetchKeys(ctxWithClient, uri)
 
 			expectedError := `unable to parse response cache headers: strconv.ParseUint: parsing "INVALID": invalid syntax`
 			Expect(jwks).To(BeNil())
@@ -549,7 +596,7 @@ var _ = Describe("Jwks tests", func() {
 			now := time.Now().UTC()
 			ctx := context.Background()
 			ctxWithClient := context.WithValue(ctx, oauth2.HTTPClient, mockClient)
-			jwks, expiry, err := updateKeys(ctxWithClient, uri)
+			jwks, expiry, err := fetchKeys(ctxWithClient, uri)
 
 			Expect(jwks).To(Equal(expectedKeySet.Keys))
 			Expect(expiry).Should(BeTemporally(">", now))


### PR DESCRIPTION
RemoteKeyStore had a sync.Mutex, but only the writer (updateKeys) acquired it. The read paths ByUse and ById checked r.Expiry and ranged over r.Keys without holding the lock, so a lookup could race with a concurrent refresh reassigning the slice.